### PR TITLE
add user-specified title support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 node_modules
+log
+tmp/**/*
+.idea/*
+.idea/**/*
+*.iml
+*.sublime-*
+.console_history
+*.swp
 .DS_Store
+tmp
+.env
+yarn-error.log
+package-lock.json
+dist

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Calling it with a number will initiate a timer. Its notification will continue f
 
 Calling it with `quit` as the argument will exit all running timers.
 
+Any optional additional arguments are treated as the title to appear menu tray for the timer, which can be used to distinguish multiple timers.
+This appears as a disabled first item in the menu, as not to take up precious room on the bar itself.
+
+```bash
+SandwichTimer.app/Contents/MacOS/SandwichTimer 20 Check Laundry
+```
+
 ## Install
 
 [Download the latest version](https://github.com/vitorgalvao/sandwichtimer/releases), or install via the [SandwichTimer Alfred Workflow](https://github.com/vitorgalvao/alfred-workflows/tree/master/SandwichTimer).

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Calling it with a number will initiate a timer. Its notification will continue f
 
 Calling it with `quit` as the argument will exit all running timers.
 
-Any optional additional arguments are treated as the title to appear menu tray for the timer, which can be used to distinguish multiple timers.
-This appears as a disabled first item in the menu, as not to take up precious room on the bar itself.
+For custom minute timers, any optional additional arguments are treated as the title to appear menu tray for the timer, which can be used to distinguish multiple timers.
+This appears as a disabled first item in the menu, as not to take up precious room on the bar itself, and will show on the notifications when done.
 
 ```bash
 SandwichTimer.app/Contents/MacOS/SandwichTimer 20 Check Laundry

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Calling it with a number will initiate a timer. Its notification will continue f
 
 Calling it with `quit` as the argument will exit all running timers.
 
-For custom minute timers, any optional additional arguments are treated as the title to appear menu tray for the timer, which can be used to distinguish multiple timers.
+For custom minute timers, an optional additional argument is treated as the title to appear menu tray for the timer, which can be used to distinguish multiple timers.
 This appears as a disabled first item in the menu, as not to take up precious room on the bar itself, and will show on the notifications when done.
 
 ```bash
-SandwichTimer.app/Contents/MacOS/SandwichTimer 20 Check Laundry
+SandwichTimer.app/Contents/MacOS/SandwichTimer 20 "Check Laundry"
 ```
 
 ## Install

--- a/app/main.js
+++ b/app/main.js
@@ -1,23 +1,52 @@
-const appName = 'SandwichTimer';
+/* eslint-disable no-use-before-define */
+
+const APP_NAME = 'SandwichTimer';
 
 // Global references to avoid problems on garbage collection
 let appTray;
 let notification;
+let trayMenu;
 
-const {app, Menu, Notification, Tray} = require('electron');
-const {spawn} = require('child_process');
-const menuTemplate = [
-  { label: 'Start Pomodoro', click: function () { runPomodoro('work'); } },
-  { label: 'Stop Timer', click: function () { stopTimer(); } },
+const {
+  app, Menu, Notification, Tray,
+} = require('electron'); // eslint-disable-line import/no-extraneous-dependencies
+const { spawn } = require('child_process');
+
+const MENU_TEMPLATE = [
   { type: 'separator' },
-  { label: 'Quit ' + appName, click: function () { app.quit(); } }
-]
-const trayMenu = Menu.buildFromTemplate(menuTemplate);
+  {
+    id: 'Start',
+    label: 'Start Pomodoro',
+    click() {
+      // noinspection JSIgnoredPromiseFromCall
+      runPomodoro('work');
+    },
+  },
+  {
+    id: 'Stop',
+    label: 'Stop Timer',
+    click() {
+      stopTimer();
+    },
+  },
+  { type: 'separator' },
+  {
+    id: 'Quit',
+    label: `Quit ${APP_NAME}`,
+    click() {
+      app.quit();
+    },
+  },
+];
 
-let globalCountdownId = Date.now(); // By setting a global ID each timer is checked against, we ensure they are terminated correctly. This way we can have a high setTimeout without worrying about overlapping timers.
+/*
+ * By setting a global ID each timer is checked against, we ensure they are terminated correctly.
+ * This way we can have a high setTimeout without worrying about overlapping timers.
+ */
+let globalCountdownId = Date.now();
 
 function asyncWait(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function msToMin(milliseconds) {
@@ -28,46 +57,56 @@ function minToMs(minutes) {
   return minutes * 1000 * 60;
 }
 
-function showMenuOption(makeVisible) {
-  if (makeVisible === 'Start') {
-    trayMenu.items[0].visible = true;
-    trayMenu.items[1].visible = false;
-    return;
-  }
-
-  if (makeVisible === 'Stop') {
-    trayMenu.items[0].visible = false;
-    trayMenu.items[1].visible = true;
-    return;
-  }
+function toggleStartStopMenu(makeVisible) {
+  const [on, off] = makeVisible === 'Start' ? ['Start', 'Stop'] : ['Stop', 'Start'];
+  trayMenu.items.forEach((item) => {
+    if (item.id === on) {
+      item.visible = true;
+    } else if (item.id === off) {
+      item.visible = false;
+    }
+  });
 }
 
-async function showNotification(time) {
+function showNotification(time) {
   let options;
+  const title = trayMenu.items.find((i) => i.id === 'Title').label;
 
   if (time === 'work') {
     options = {
       title: 'Finished work time',
       body: 'Start the break at any time',
       sound: 'Blow',
-      actions: [{ type: 'button', text: 'Start break' }]
-    }
+      actions: [
+        {
+          type: 'button',
+          text: 'Start break',
+        }],
+    };
   } else if (time === 'break') {
     options = {
       title: 'Break is over',
       body: 'Ready to start a new pomodoro whenever you want',
       sound: 'Blow',
-      actions: [{ type: 'button', text: 'New pomodoro' }]
-    }
+      actions: [
+        {
+          type: 'button',
+          text: 'New pomodoro',
+        }],
+    };
   } else {
-    const plurality = time == '1' ? 'minute' : 'minutes'
+    const plurality = time === '1' ? 'minute' : 'minutes';
 
     options = {
-      title: 'Timer done!',
-      body: 'It was set for ' + time + ' ' + plurality,
+      title: `${title} timer done!`,
+      body: `It was set for ${time} ${plurality}`,
       sound: 'Submarine',
-      actions: [{ type: 'button', text: 'Quit' }]
-    }
+      actions: [
+        {
+          type: 'button',
+          text: 'Quit',
+        }],
+    };
   }
 
   notification = new Notification(options);
@@ -75,33 +114,31 @@ async function showNotification(time) {
 
   if (time === 'work') {
     appTray.setTitle('Work over');
-    notification.on('action', function() { runPomodoro('break'); });
-    notification.on('click',  function() { runPomodoro('break'); });
+    notification.on('action', () => runPomodoro('break'));
+    notification.on('click', () => runPomodoro('break'));
   } else if (time === 'break') {
     appTray.setTitle('Break over');
-    notification.on('action', function() { runPomodoro('work'); });
-    notification.on('click',  function() { runPomodoro('work'); });
+    notification.on('action', () => runPomodoro('work'));
+    notification.on('click', () => runPomodoro('work'));
   } else {
-    appTray.setTitle('Timer over');
-    notification.on('action', function() { app.quit(); });
-    notification.on('click',  function() { app.quit(); });
+    appTray.setTitle(`${title} timer over`);
+    notification.on('action', () => app.quit());
+    notification.on('click', () => app.quit());
   }
 }
 
-function stopTimer() {
-  globalCountdownId = Date.now();
-  showMenuOption('Start');
+function stopTimer(manually = true) {
+  if (manually) {
+    globalCountdownId = Date.now();
+  }
   appTray.setTitle('');
-}
-
-async function runPomodoro(time) {
-  let minutes = (time === 'work') ? '25' : '5'
-  if (await countdown(minutes)) showNotification(time); // Only show notification if timer ended successfully
+  setTrayMenu('Pomodoro');
+  toggleStartStopMenu('Start');
 }
 
 async function countdown(minutesToWait) {
-  showMenuOption('Stop');
-  let localCountdownId = globalCountdownId;
+  toggleStartStopMenu('Stop');
+  const localCountdownId = globalCountdownId;
 
   const duration = minToMs(minutesToWait);
   const start = Date.now();
@@ -109,42 +146,104 @@ async function countdown(minutesToWait) {
 
   while (remainingMinutes > 0) {
     appTray.setTitle(remainingMinutes.toString());
+    // eslint-disable-next-line no-await-in-loop
     await asyncWait(20000);
 
-    if (localCountdownId !== globalCountdownId) return false; // This means the timer was terminated manually (and the global ID was changed)
+    // This means the timer was terminated manually (and the global ID was changed)
+    if (localCountdownId !== globalCountdownId) {
+      return false;
+    }
 
     remainingMinutes = Math.ceil(msToMin(duration - (Date.now() - start)));
   }
 
-  stopTimer();
+  stopTimer(false);
   return true;
 }
 
-app.on('ready', function(){
-  if (process.defaultApp) process.argv.shift(); // Normalise argument positions when running with electron and built app
-  const argument = process.argv[1];
+async function runPomodoro(time) {
+  const minutes = (time === 'work') ? '25' : '5';
 
-  if (argument === 'quit') {
-    spawn('pkill', ['-i', appName]);
-    app.quit();
-    return; // if we do not return, the next lines will still execute before the app quits and we'll get a flash of a new instance
+  // Only show notification if timer ended successfully
+  if (await countdown(minutes)) {
+    showNotification(time);
+  }
+}
+
+function setTrayMenu(trayTitle) {
+  const menuTitle = {
+    id: 'Title',
+    label: trayTitle,
+    enabled: false,
+  };
+
+  const menu = [...MENU_TEMPLATE];
+  menu.unshift(menuTitle);
+  trayMenu = Menu.buildFromTemplate(menu);
+  appTray.setContextMenu(trayMenu);
+  appTray.setToolTip(trayTitle);
+}
+
+function parseArgs() {
+  // Normalise argument positions when running with electron and built app
+  if (process.defaultApp) {
+    process.argv.shift();
   }
 
-  appTray = new Tray(__dirname + '/iconTemplate@2x.png');
-  appTray.setContextMenu(trayMenu);
+  // usage is: sandwichtimer <minutes | pomodoro | quit> [title]
+  //   where title could be given in single or separate words
+  // from Alfred, all args will be given as a single first argument
+  // from CLI, it could be any number of arguments, so concat them all together
+  // so they can be processed uniformly
+  const args = process.argv.slice(1).join(' ').split(' ');
 
-  if ((isNaN(argument)) || argument === '' || argument === 0 || argument === 'pomodoro') {
+  const mainArgument = args.shift();
+  const trayTitle = args.join(' ');
+  return [mainArgument, trayTitle];
+}
+
+app.on('ready', () => {
+  const [argument, suppliedTitle] = parseArgs();
+
+  if (argument === 'quit') {
+    spawn('pkill', ['-i', APP_NAME]);
+    app.quit();
+
+    // if we do not return, the next lines will still execute before the app quits and we'll get a flash of a new instance
+    return;
+  }
+
+  // noinspection JSCheckFunctionSignatures
+  const startPomodoro = (!argument || isNaN(argument) || argument === 'pomodoro'); // eslint-disable-line no-restricted-globals
+
+  let trayTitle;
+  if (suppliedTitle) {
+    trayTitle = suppliedTitle;
+    trayTitle = suppliedTitle;
+  } else if (startPomodoro) {
+    trayTitle = 'Pomodoro';
+  } else {
+    trayTitle = `${argument} min`;
+  }
+
+  appTray = new Tray(`${__dirname}/iconTemplate@2x.png`);
+  setTrayMenu(trayTitle);
+
+  if (startPomodoro) {
+    // noinspection JSIgnoredPromiseFromCall
     runPomodoro('work');
     return;
   }
 
-  (async function() {
+  (async function () {
+    const localCountdownId = globalCountdownId;
     await countdown(argument);
 
     // For a regular timer, keep making noise until the notification is acted upon
-    while (true) {
+    while (localCountdownId === globalCountdownId) {
       showNotification(argument);
+      // eslint-disable-next-line no-await-in-loop
       await asyncWait(2000);
     }
-  })();
+  }());
 });

--- a/app/main.js
+++ b/app/main.js
@@ -1,49 +1,21 @@
-/* eslint-disable no-use-before-define */
-
-const APP_NAME = 'SandwichTimer';
+const appName = 'SandwichTimer';
 
 // Global references to avoid problems on garbage collection
 let appTray;
 let notification;
 let trayMenu;
+let title = null;
 
-const {
-  app, Menu, Notification, Tray,
-} = require('electron'); // eslint-disable-line import/no-extraneous-dependencies
+const { app, Menu, Notification, Tray } = require('electron');
 const { spawn } = require('child_process');
-
-const MENU_TEMPLATE = [
+const menuTemplate = [
+  { id: 'Start', label: 'Start Pomodoro', click: function () { runPomodoro('work'); } },
+  { id: 'Stop', label: 'Stop Timer', click: function () { stopTimer(); } },
   { type: 'separator' },
-  {
-    id: 'Start',
-    label: 'Start Pomodoro',
-    click() {
-      // noinspection JSIgnoredPromiseFromCall
-      runPomodoro('work');
-    },
-  },
-  {
-    id: 'Stop',
-    label: 'Stop Timer',
-    click() {
-      stopTimer();
-    },
-  },
-  { type: 'separator' },
-  {
-    id: 'Quit',
-    label: `Quit ${APP_NAME}`,
-    click() {
-      app.quit();
-    },
-  },
+  { id: 'Quit', label: `Quit ${appName}`, click: function () { app.quit(); } }
 ];
 
-/*
- * By setting a global ID each timer is checked against, we ensure they are terminated correctly.
- * This way we can have a high setTimeout without worrying about overlapping timers.
- */
-let globalCountdownId = Date.now();
+let globalCountdownId = Date.now(); // By setting a global ID each timer is checked against, we ensure they are terminated correctly. This way we can have a high setTimeout without worrying about overlapping timers.
 
 function asyncWait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -70,42 +42,29 @@ function toggleStartStopMenu(makeVisible) {
 
 function showNotification(time) {
   let options;
-  const title = trayMenu.items.find((i) => i.id === 'Title').label;
 
   if (time === 'work') {
     options = {
       title: 'Finished work time',
       body: 'Start the break at any time',
       sound: 'Blow',
-      actions: [
-        {
-          type: 'button',
-          text: 'Start break',
-        }],
+      actions: [{ type: 'button', text: 'Start break' }],
     };
   } else if (time === 'break') {
     options = {
       title: 'Break is over',
       body: 'Ready to start a new pomodoro whenever you want',
       sound: 'Blow',
-      actions: [
-        {
-          type: 'button',
-          text: 'New pomodoro',
-        }],
+      actions: [{ type: 'button', text: 'New pomodoro' }],
     };
   } else {
     const plurality = time === '1' ? 'minute' : 'minutes';
 
     options = {
-      title: `${title} timer done!`,
+      title: title ? `${title} timer done!` : 'Timer done!',
       body: `It was set for ${time} ${plurality}`,
       sound: 'Submarine',
-      actions: [
-        {
-          type: 'button',
-          text: 'Quit',
-        }],
+      actions: [{ type: 'button', text: 'Quit' }],
     };
   }
 
@@ -121,7 +80,7 @@ function showNotification(time) {
     notification.on('action', () => runPomodoro('work'));
     notification.on('click', () => runPomodoro('work'));
   } else {
-    appTray.setTitle(`${title} timer over`);
+    appTray.setTitle(title ? `${title} timer over` : 'Timer over');
     notification.on('action', () => app.quit());
     notification.on('click', () => app.quit());
   }
@@ -132,7 +91,7 @@ function stopTimer(manually = true) {
     globalCountdownId = Date.now();
   }
   appTray.setTitle('');
-  setTrayMenu('Pomodoro');
+  setTrayMenu();
   toggleStartStopMenu('Start');
 }
 
@@ -146,7 +105,6 @@ async function countdown(minutesToWait) {
 
   while (remainingMinutes > 0) {
     appTray.setTitle(remainingMinutes.toString());
-    // eslint-disable-next-line no-await-in-loop
     await asyncWait(20000);
 
     // This means the timer was terminated manually (and the global ID was changed)
@@ -171,17 +129,24 @@ async function runPomodoro(time) {
 }
 
 function setTrayMenu(trayTitle) {
-  const menuTitle = {
-    id: 'Title',
-    label: trayTitle,
-    enabled: false,
-  };
+  const menu = [...menuTemplate];
 
-  const menu = [...MENU_TEMPLATE];
-  menu.unshift(menuTitle);
+  // if given a title, prepend to the template,
+  // else, replace menu with one with no title
+  if (trayTitle) {
+    const separator = { type: 'separator' };
+    const menuTitle = {
+      id: 'Title',
+      label: trayTitle,
+      enabled: false,
+    };
+
+    menu.unshift(separator);
+    menu.unshift(menuTitle);
+  }
+
   trayMenu = Menu.buildFromTemplate(menu);
   appTray.setContextMenu(trayMenu);
-  appTray.setToolTip(trayTitle);
 }
 
 function parseArgs() {
@@ -206,32 +171,27 @@ app.on('ready', () => {
   const [argument, suppliedTitle] = parseArgs();
 
   if (argument === 'quit') {
-    spawn('pkill', ['-i', APP_NAME]);
+    spawn('pkill', ['-i', appName]);
     app.quit();
 
     // if we do not return, the next lines will still execute before the app quits and we'll get a flash of a new instance
     return;
   }
 
-  // noinspection JSCheckFunctionSignatures
-  const startPomodoro = (!argument || isNaN(argument) || argument === 'pomodoro'); // eslint-disable-line no-restricted-globals
-
-  let trayTitle;
-  if (suppliedTitle) {
-    trayTitle = suppliedTitle;
-  } else if (startPomodoro) {
-    trayTitle = 'Pomodoro';
-  } else {
-    trayTitle = `${argument} min`;
-  }
-
   appTray = new Tray(`${__dirname}/iconTemplate@2x.png`);
-  setTrayMenu(trayTitle);
 
-  if (startPomodoro) {
-    // noinspection JSIgnoredPromiseFromCall
+  if ((!argument || isNaN(argument) || argument === 'pomodoro')) {
+    setTrayMenu();
     runPomodoro('work');
     return;
+  } else {
+    if (suppliedTitle) {
+      title = suppliedTitle;
+    } else {
+      title = `${argument} min`;
+    }
+
+    setTrayMenu(title);
   }
 
   (async function () {
@@ -241,7 +201,6 @@ app.on('ready', () => {
     // For a regular timer, keep making noise until the notification is acted upon
     while (localCountdownId === globalCountdownId) {
       showNotification(argument);
-      // eslint-disable-next-line no-await-in-loop
       await asyncWait(2000);
     }
   }());

--- a/app/main.js
+++ b/app/main.js
@@ -156,14 +156,10 @@ function parseArgs() {
   }
 
   // usage is: sandwichtimer <minutes | pomodoro | quit> [title]
-  //   where title could be given in single or separate words
-  // from Alfred, all args will be given as a single first argument
-  // from CLI, it could be any number of arguments, so concat them all together
-  // so they can be processed uniformly
-  const args = process.argv.slice(1).join(' ').split(' ');
+  const args = process.argv.slice(1);
 
   const mainArgument = args.shift();
-  const trayTitle = args.join(' ');
+  const trayTitle = args.shift();
   return [mainArgument, trayTitle];
 }
 

--- a/app/main.js
+++ b/app/main.js
@@ -219,7 +219,6 @@ app.on('ready', () => {
   let trayTitle;
   if (suppliedTitle) {
     trayTitle = suppliedTitle;
-    trayTitle = suppliedTitle;
   } else if (startPomodoro) {
     trayTitle = 'Pomodoro';
   } else {

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,6 @@
     "build-macos": "electron-builder --dir",
     "package": "npm run package-macos",
     "package-macos": "electron-builder",
-    "lint": "eslint .",
     "clean": "rm -rf dist"
   },
   "repository": {
@@ -41,75 +40,6 @@
   "homepage": "https://github.com/vitorgalvao/sandwichtimer",
   "devDependencies": {
     "electron": "^5.0.1",
-    "electron-builder": "^20.40.2",
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.1.0",
-    "eslint-plugin-import": "^2.20.2"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "node": true,
-      "es6": true
-    },
-    "extends": [
-      "airbnb-base"
-    ],
-    "rules": {
-      "func-names": [
-        "error",
-        "never"
-      ],
-      "max-len": [
-        "error",
-        {
-          "code": 160
-        }
-      ],
-      "lines-between-class-members": "off",
-      "import/no-extraneous-dependencies": [
-        "error"
-      ],
-      "import/extensions": [
-        "error",
-        "always",
-        {
-          "js": "never"
-        }
-      ],
-      "indent": [
-        "error",
-        2,
-        {
-          "FunctionDeclaration": {
-            "parameters": "first"
-          },
-          "FunctionExpression": {
-            "parameters": "first"
-          },
-          "SwitchCase": 1
-        }
-      ],
-      "no-param-reassign": [
-        "error",
-        {
-          "props": false
-        }
-      ]
-    },
-    "settings": {
-      "import/resolver": {
-        "node": {
-          "extensions": [
-            ".js"
-          ]
-        }
-      }
-    },
-    "parserOptions": {
-      "parser": {
-        "ecmaVersion": 6
-      }
-    }
+    "electron-builder": "^20.40.2"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandwichtimer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Timer app controllable via CLI",
   "build": {
     "appId": "com.vitorgalvao.sandwichtimer",
@@ -20,7 +20,9 @@
     "build": "npm run build-macos",
     "build-macos": "electron-builder --dir",
     "package": "npm run package-macos",
-    "package-macos": "electron-builder"
+    "package-macos": "electron-builder",
+    "lint": "eslint .",
+    "clean": "rm -rf dist"
   },
   "repository": {
     "type": "git",
@@ -39,6 +41,75 @@
   "homepage": "https://github.com/vitorgalvao/sandwichtimer",
   "devDependencies": {
     "electron": "^5.0.1",
-    "electron-builder": "^20.40.2"
+    "electron-builder": "^20.40.2",
+    "eslint": "^6.8.0",
+    "eslint-config-airbnb-base": "^14.1.0",
+    "eslint-plugin-import": "^2.20.2"
+  },
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "node": true,
+      "es6": true
+    },
+    "extends": [
+      "airbnb-base"
+    ],
+    "rules": {
+      "func-names": [
+        "error",
+        "never"
+      ],
+      "max-len": [
+        "error",
+        {
+          "code": 160
+        }
+      ],
+      "lines-between-class-members": "off",
+      "import/no-extraneous-dependencies": [
+        "error"
+      ],
+      "import/extensions": [
+        "error",
+        "always",
+        {
+          "js": "never"
+        }
+      ],
+      "indent": [
+        "error",
+        2,
+        {
+          "FunctionDeclaration": {
+            "parameters": "first"
+          },
+          "FunctionExpression": {
+            "parameters": "first"
+          },
+          "SwitchCase": 1
+        }
+      ],
+      "no-param-reassign": [
+        "error",
+        {
+          "props": false
+        }
+      ]
+    },
+    "settings": {
+      "import/resolver": {
+        "node": {
+          "extensions": [
+            ".js"
+          ]
+        }
+      }
+    },
+    "parserOptions": {
+      "parser": {
+        "ecmaVersion": 6
+      }
+    }
   }
 }


### PR DESCRIPTION
this adds support for a user-specified title for the timer, per this request https://www.alfredforum.com/topic/11518-sandwichtimer-%E2%80%94-run-pomodoros-and-other-timers/?do=findComment&comment=68634

the changes are pretty simple.  apologies for the diffs caused by the IDE deciding to adjust the formatting... :/

1) added support for optional argument(s) following the main argument directive (quit, pomodoro, or minutes) to be treated as the timer title
  - this title appears as a disabled first item in the menu, so that the tray doesn't fill with text strings
  - since updating a menu label is not supported, it requires a full replacement of the menu to make changes.  I therefore didn't go too crazy with support for things like editing the value once set.
2) this can be a single or separate arguments, so all of these invocations are identical:
```
  app 1 my title
  app 1 "my title"
  app "1 my title" - the Alfred usage
```
3) uses ID lookup instead of absolute item positioning in menu to toggle start/stop
4) fixed 'stop timer' to work on adhoc timers as well (previously they would still continue)
5) added eslint, fixed accordingly

This is compatible with the existing Alfred workflow, so no changes required there.  (Again, it passes everything as a single argument anyway, so ${1} will now potentially include the title.)

Anyway, thanks for building the tool, and for considering these changes.