### PR TITLE
use updated sound names for Big Sur

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,5 +1,5 @@
 const appName = 'SandwichTimer';
-const osMajorRelease = parseInt(require('os').release().replace(/^(\d+)\..*/, "$1"));
+const osMajorRelease = parseInt(require('os').release().split('.')[0]);
 
 // Global references to avoid problems on garbage collection
 let appTray;

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,5 @@
 const appName = 'SandwichTimer';
+const osMajorRelease = parseInt(require('os').release().replace(/^(\d+)\..*/, "$1"));
 
 // Global references to avoid problems on garbage collection
 let appTray;
@@ -47,14 +48,14 @@ function showNotification(time) {
     options = {
       title: 'Finished work time',
       body: 'Start the break at any time',
-      sound: 'Blow',
+      sound: osMajorRelease >= 20 ? 'Breeze' : 'Blow',
       actions: [{ type: 'button', text: 'Start break' }],
     };
   } else if (time === 'break') {
     options = {
       title: 'Break is over',
       body: 'Ready to start a new pomodoro whenever you want',
-      sound: 'Blow',
+      sound: osMajorRelease >= 20 ? 'Breeze' : 'Blow',
       actions: [{ type: 'button', text: 'New pomodoro' }],
     };
   } else {
@@ -63,7 +64,7 @@ function showNotification(time) {
     options = {
       title: title ? `${title} timer done!` : 'Timer done!',
       body: `It was set for ${time} ${plurality}`,
-      sound: 'Submarine',
+      sound: osMajorRelease >= 20 ? 'Submerge' : 'Submarine',
       actions: [{ type: 'button', text: 'Quit' }],
     };
   }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandwichtimer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Timer app controllable via CLI",
   "build": {
     "appId": "com.vitorgalvao.sandwichtimer",


### PR DESCRIPTION
The timer no longer works on Big Sur because the sounds have all been renamed.  (Thanks, Apple.)  This not only makes it silent, but also prevents the notifications altogether.

I've tried adding the classic sounds back at the filesystem level (both as files and symlinks) in ~/Library/Sounds, and while they then appear in System Preferences -> Sounds, the notifications still can't find them.  (It's even weirder than that, as Apple kept the old file names but mapped new user-level names.  Ugh.)

If I update the application to use the new sound names (Blow -> Breeze, Submarine -> Submerge), it works fine - both the visual notification and the sound function correctly.

I wrapped this change in a check for macos >= Big Sur, as not to break usage on older OS versions.