### PR TITLE
build universal macos, not just x64

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,5 +1,5 @@
 const appName = 'SandwichTimer';
-const osMajorRelease = parseInt(require('os').release().replace(/^(\d+)\..*/, "$1"));
+const osMajorRelease = parseInt(require('os').release().split('.')[0]);
 
 // Global references to avoid problems on garbage collection
 let appTray;

--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,5 @@
 const appName = 'SandwichTimer';
+const osMajorRelease = parseInt(require('os').release().replace(/^(\d+)\..*/, "$1"));
 
 // Global references to avoid problems on garbage collection
 let appTray;
@@ -47,14 +48,14 @@ function showNotification(time) {
     options = {
       title: 'Finished work time',
       body: 'Start the break at any time',
-      sound: 'Blow',
+      sound: osMajorRelease >= 20 ? 'Breeze' : 'Blow',
       actions: [{ type: 'button', text: 'Start break' }],
     };
   } else if (time === 'break') {
     options = {
       title: 'Break is over',
       body: 'Ready to start a new pomodoro whenever you want',
-      sound: 'Blow',
+      sound: osMajorRelease >= 20 ? 'Breeze' : 'Blow',
       actions: [{ type: 'button', text: 'New pomodoro' }],
     };
   } else {
@@ -63,7 +64,7 @@ function showNotification(time) {
     options = {
       title: title ? `${title} timer done!` : 'Timer done!',
       body: `It was set for ${time} ${plurality}`,
-      sound: 'Submarine',
+      sound: osMajorRelease >= 20 ? 'Submerge' : 'Submarine',
       actions: [{ type: 'button', text: 'Quit' }],
     };
   }

--- a/app/package.json
+++ b/app/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "electron main.js",
     "build": "npm run build-macos",
-    "build-macos": "electron-builder --dir",
+    "build-macos": "electron-builder --dir --mac --universal",
     "package": "npm run package-macos",
     "package-macos": "electron-builder",
     "clean": "rm -rf dist"
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/vitorgalvao/sandwichtimer",
   "devDependencies": {
-    "electron": "^10.1.4",
-    "electron-builder": "^22.09.1"
+    "electron": "^12.0.4",
+    "electron-builder": "^22.10.5"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandwichtimer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Timer app controllable via CLI",
   "build": {
     "appId": "com.vitorgalvao.sandwichtimer",


### PR DESCRIPTION
This is an attempt to build a universal app rather than just x64.  The changes are quite simple - use latest builder, and pass the target flags.

I can only test it on my local x64 Big Sur machine, and I cannot test the code signing.  But I can successfully run this universal app locally.

Note that the app is significantly larger, since it is the sum of all architectures.